### PR TITLE
Add Triton conv1d implementation and parity test

### DIFF
--- a/causal_conv1d/__init__.py
+++ b/causal_conv1d/__init__.py
@@ -1,3 +1,4 @@
 __version__ = "1.5.0.post8"
 
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_update
+from causal_conv1d.causal_conv1d_triton import causal_conv1d_triton

--- a/causal_conv1d/causal_conv1d_triton.py
+++ b/causal_conv1d/causal_conv1d_triton.py
@@ -1,0 +1,62 @@
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def _causal_conv1d_fw(
+    X, W, B, OUT,
+    seqlen, width,
+    stride_x_batch, stride_x_seqlen, stride_x_dim,
+    stride_w_dim,
+    stride_out_batch, stride_out_seqlen, stride_out_dim,
+    BLOCK_N: tl.constexpr, HAS_BIAS: tl.constexpr,
+):
+    b = tl.program_id(0)
+    d = tl.program_id(1)
+    n = tl.program_id(2) * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask_n = n < seqlen
+
+    x_ptr_base = X + b * stride_x_batch + d * stride_x_dim
+    acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    for k in range(width):
+        k_rev = width - 1 - k
+        w_val = tl.load(W + d * stride_w_dim + k_rev)
+        x_ptrs = x_ptr_base + (n - k) * stride_x_seqlen
+        x_val = tl.load(x_ptrs, mask=mask_n & (n >= k), other=0.0)
+        acc += x_val.to(tl.float32) * w_val.to(tl.float32)
+
+    if HAS_BIAS:
+        acc += tl.load(B + d)
+
+    out_ptrs = OUT + b * stride_out_batch + n * stride_out_seqlen + d * stride_out_dim
+    tl.store(out_ptrs, acc.to(OUT.dtype.element_ty), mask=mask_n)
+
+
+def causal_conv1d_triton(x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+    """Depthwise causal conv1d implemented in Triton.
+
+    Args:
+        x: (batch, dim, seqlen)
+        weight: (dim, width)
+        bias: (dim,) optional
+    Returns:
+        out: (batch, dim, seqlen)
+    """
+    assert x.is_cuda and weight.is_cuda
+    batch, dim, seqlen = x.shape
+    width = weight.shape[1]
+    x_cl = x.transpose(1, 2).contiguous()  # (batch, seqlen, dim)
+    out = torch.empty_like(x_cl)
+    BLOCK_N = 128
+    grid = (batch, dim, triton.cdiv(seqlen, BLOCK_N))
+    bias_ptr = bias if bias is not None else x.new_empty(1)
+    with torch.cuda.device(x.device):
+        _causal_conv1d_fw[grid](
+            x_cl, weight, bias_ptr, out,
+            seqlen, width,
+            x_cl.stride(0), x_cl.stride(1), x_cl.stride(2),
+            weight.stride(0),
+            out.stride(0), out.stride(1), out.stride(2),
+            BLOCK_N=BLOCK_N, HAS_BIAS=bias is not None
+        )
+    return out.transpose(1, 2)

--- a/tests/test_causal_conv1d.py
+++ b/tests/test_causal_conv1d.py
@@ -11,6 +11,7 @@ from einops import rearrange
 
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_fn, causal_conv1d_ref
 from causal_conv1d.causal_conv1d_interface import causal_conv1d_update, causal_conv1d_update_ref
+from causal_conv1d.causal_conv1d_triton import causal_conv1d_triton
 from causal_conv1d.causal_conv1d_varlen import causal_conv1d_varlen_states, causal_conv1d_varlen_states_ref
 
 
@@ -349,3 +350,15 @@ def test_causal_conv1d_varlen(dim, seqlen, width, has_bias, silu_activation, ity
     assert torch.allclose(weight.grad, weight_ref.grad, rtol=rtolw, atol=atolw)
     if has_bias:
         assert torch.allclose(bias.grad, bias_ref.grad, rtol=rtolw, atol=atolw)
+
+
+def test_triton_causal_conv1d_parity():
+    device = "cuda"
+    torch.manual_seed(0)
+    batch, dim, seqlen, width = 2, 8, 32, 3
+    x = torch.randn(batch, dim, seqlen, device=device, dtype=torch.float16)
+    weight = torch.randn(dim, width, device=device, dtype=torch.float16)
+    bias = torch.randn(dim, device=device, dtype=torch.float16)
+    out_triton = causal_conv1d_triton(x, weight, bias)
+    out_ref = causal_conv1d_ref(x, weight, bias)
+    assert torch.allclose(out_triton, out_ref, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## Summary
- implement a Triton depthwise causal conv1d kernel
- expose `causal_conv1d_triton` in the package
- add a test that checks parity with the reference implementation
- fix weight orientation bug in Triton kernel

## Testing
- `pytest -k triton_causal_conv1d_parity -q` *(fails: ModuleNotFoundError: No module named 'torch')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.